### PR TITLE
Add serde feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,7 @@ dependencies = [
  "bindgen",
  "cc",
  "libc",
+ "serde",
 ]
 
 [[package]]
@@ -263,6 +264,26 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,11 @@ categories = ["algorithms", "external-ffi-bindings"]
 [features]
 generate-bindings = ["bindgen"]
 update-bindings = ["generate-bindings"]
+serde = ["dep:serde"]
 
 [dependencies]
 libc = "0.2"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [build-dependencies]
 bindgen = { version = "0.69.4", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -49,7 +49,7 @@ fn main() {
 
     #[cfg(feature = "generate-bindings")]
     {
-        let builder = bindgen::Builder::default()
+        let mut builder = bindgen::Builder::default()
             .header("clipper2c/include/clipper2c.h")
             .header("clipper2c/include/types.h")
             .allowlist_type("ClipperClipperD")

--- a/build.rs
+++ b/build.rs
@@ -49,7 +49,7 @@ fn main() {
 
     #[cfg(feature = "generate-bindings")]
     {
-        let mut builder = bindgen::Builder::default()
+        let builder = bindgen::Builder::default()
             .header("clipper2c/include/clipper2c.h")
             .header("clipper2c/include/types.h")
             .allowlist_type("ClipperClipperD")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@
 #[cfg(test)]
 mod test;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[cfg(all(not(feature = "update-bindings"), feature = "generate-bindings"))]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 


### PR DESCRIPTION
Serde deserializers can be written manually but they are quite unsightly. To add serde support to clipper2 I found it nicer to just derive `Serialize` and `Deserialize` for `ClipperPoint64` in here.