### PR TITLE
Avoid panic for wasm32-unknown-unknown in build.rs stdlib linking

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -40,6 +40,9 @@ fn main() {
         }
         ("macos", _) | ("ios", _) => println!("cargo:rustc-link-lib=dylib=c++"),
         ("windows", "msvc") => {}
+        // For wasm32-unknown-unknown the C++ stdlib is compiled into the .a
+        // archive by the WASI SDK toolchain, so no separate link step is needed.
+        ("unknown", _) => {}
         _ => unimplemented!(
             "target_os: {}, target_env: {}",
             target_os.as_str(),


### PR DESCRIPTION
I ran into this while trying to build `clipper2` for `wasm32-unknown-unknown`.

Right now, `clipper2c-sys 0.1.6` hits the `unimplemented!()` branch because `CARGO_CFG_TARGET_OS` resolves to `"unknown"` for that target. This causes the build to fail even though the setup itself is valid.

In my case (using the WASI SDK toolchain), the C++ standard library is already bundled into the static `libclipper2c.a`, so an additional `rustc-link-lib` step isn’t needed. Adding a `("unknown", _)` match arm avoids the panic and allows the build to complete successfully.

That said, this change is based on limited Rust/WASM experience and some experimentation in a side project ([https://github.com/max-scopp/slicer-engine](https://github.com/max-scopp/slicer-engine)). It might be worth confirming whether simply skipping the link step is the right long-term behavior, or if a more explicit safeguard/check would be better here.
